### PR TITLE
使用小程序自带请求队列代替 miniprogam-queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # [miniprogram-network](https://github.com/NewFuture/miniprogram-network)
 
-> 小程序网络库,提供完整`代码自动完成` 和 `类型检查`,支持`Promise`、`队列`、自动`重试`、`缓存`、`取消`、`自定义超时`、全局`拦截`、和`事件监听`等……
+> 小程序网络库,提供完整`代码自动完成` 和 `类型检查`,支持`Promise`、自动`重试`、`缓存`、`取消`、`自定义超时`、全局`拦截`、和`事件监听`等……
 >
-> Redefine the network API of Wechat MiniProgram, including full `IntelliSense` and `Type Checking`, with `Promise`,`Queue`,`retry`,`Cache`,`CancelToken`,`timeout`, global `interceptors`, `event listeners` and more.
+> Redefine the network API of Wechat MiniProgram, including full `IntelliSense` and `Type Checking`, with `Promise`,`retry`,`Cache`,`CancelToken`,`timeout`, global `interceptors`, `event listeners` and more.
 
 ## Features 主要功能
 
 * [x] Promise<T>泛型Promise支持
-* [x] Queue 队列支持(可插队)
 * [x] Retry 网络错误自动重试
 * [x] Cache 底层缓存支持(包括并发请求合并)
 * [x] CancelToken 可取消操作
 * [x] Timeout 自定义超时时间
+* [x] timestamp 记录耗时统计(需开启配置)
 * [x] 每个请求的原生回调接口支持(`onHeadersReceived`事件)和(`onProgressUpdate`事件)
 * [x] Interceptors 拦截器 `transformSend`/ `transformRresponse`自定义数据拦截
 * [x] Listeners 全局事件监听`onSend`,`onResponse`,`onRejected`,`onAbort`,`onComplete`
@@ -104,7 +104,7 @@ download<string>('network/','lcoalpath',{
 > 如果担心包依赖多,可使用[miniprogram-build](https://github.com/NewFuture/miniprogram-build) 打包小程序rollup 精简为单文件。
 
 
-![network-dependencies-graph](https://user-images.githubusercontent.com/6290356/53808057-35143980-3f8c-11e9-8618-4d6e7c5eaa1e.png)
+![network-dependencies-graph](https://user-images.githubusercontent.com/6290356/58758745-6f24b580-8552-11e9-890d-02c4559eb400.png)
 
 * [miniprogram-network](network) All in one 小程序网络库库合集[![npm version](https://badge.fury.io/js/miniprogram-network.svg)](https://npmjs.com/package/miniprogram-network)
     * `Request` from `miniprogram-request`
@@ -114,7 +114,6 @@ download<string>('network/','lcoalpath',{
 * [miniprogram-request](request) 小程序请求库 [![npm version](https://badge.fury.io/js/miniprogram-request.svg)](https://npmjs.com/package/miniprogram-request)
     * [x] Promise支持+finally+泛型
     * [x] CancelToken 取消支持
-    * [x] Queue 底层队列维护，支持插队
     * [x] retry 网络错误重试
     * [x] Interceptors 自定义请求/响应拦截
     * [x] Listeners 事件监听
@@ -125,27 +124,29 @@ download<string>('network/','lcoalpath',{
     * [x] Cancelable 可取消
     * [x] OnProgressUpdate 进度回调
     * [x] OnHeadersReceived 响应头回调
-    * [x] Queue 底层队列维护，支持插队
     * [x] retry 网络错误重试
     * [x] Interceptors 自定义请求/响应拦截
     * [x] Listeners 事件监听
 * [miniprogram-downloader](downloader) 小程序下载库 [![npm version](https://badge.fury.io/js/miniprogram-downloader.svg)](https://npmjs.com/package/miniprogram-downloader)
     * [x] Promise支持+finally+泛型
     * [x] Cancelable 可取消
-    * [x] Queue 底层队列维护，支持插队
     * [x] retry 网络错误重试
     * [x] OnProgressUpdate 进度回调
     * [x] OnHeadersReceived 响应头回调
     * [x] Interceptors 自定义请求/响应拦截
     * [x] Listeners 事件监听
-* [miniprogram-queue](queue) 小程序API队列封装 [![npm version](https://badge.fury.io/js/miniprogram-queue.svg)](https://npmjs.com/package/miniprogram-queue)
+* [miniprogram-network-life-cycle](life-cycle) 网络操作流程和事件
+    * [x] 事件周期监听器
+    * [x] 事件周期拦截器
+    * [x] 自定义超时
+    * [x] 时间戳打点
+![life-cycle](https://user-images.githubusercontent.com/6290356/49631309-6bddc080-fa2c-11e8-9a41-88fb50b2a1b7.png)
+* [miniprogram-fetch](fetch) 小程序中使用[Fetch API](https://developer.mozilla.org/zh-CN/docs/Web/API/Fetch_API/Using_Fetch) [![npm version](https://badge.fury.io/js/miniprogram-fetch.svg)](https://npmjs.com/package/miniprogram-fetch)
+    * [x] 自动队列支持
+* [miniprogram-queue](queue) 自定义队列封装 [![npm version](https://badge.fury.io/js/miniprogram-queue.svg)](https://npmjs.com/package/miniprogram-queue)
     * [x] 可自动注入/手动管理
     * [x] 支持取消操作(`abort`)
     * [x] OnProgressUpdate 进度回调
     * [x] OnHeadersReceived 响应头回调
     * [x] 支持插队
     * [x] 支持自定义超时
-* [miniprogram-network-life-cycle](life-cycle) 网络操作流程和事件
-![life-cycle](https://user-images.githubusercontent.com/6290356/49631309-6bddc080-fa2c-11e8-9a41-88fb50b2a1b7.png)
-* [miniprogram-fetch](fetch) 小程序中使用[Fetch API](https://developer.mozilla.org/zh-CN/docs/Web/API/Fetch_API/Using_Fetch) [![npm version](https://badge.fury.io/js/miniprogram-fetch.svg)](https://npmjs.com/package/miniprogram-fetch)
-    * [x] 自动队列支持

--- a/downloader/README.md
+++ b/downloader/README.md
@@ -20,7 +20,6 @@
 * [x] `cancelToken` 取消 (_只能请求时设置for single request_) 
 * [x] `onProgressUpdate` 下载进度响应 (_只能请求时设置for single request_) 
 * [x] `onHeadersReceived` 接收头响应 (_只能请求时设置for single request_) 
-* [x] `jump` 是否插队 (_只能请求时设置for single request_)
 * [x] `timeout` 自定义超时时间ms (_只能请求时设置for single request_)
 * [x] `headers` 请求头
 * [x] `params` URL参数

--- a/downloader/package.json
+++ b/downloader/package.json
@@ -38,7 +38,6 @@
     },
     "dependencies": {
         "miniprogram-network-life-cycle": "^4.5.3",
-        "miniprogram-network-utils": "^4.5.2",
-        "miniprogram-queue": "^4.5.1"
+        "miniprogram-network-utils": "^4.5.2"
     }
 }

--- a/downloader/src/downloader.ts
+++ b/downloader/src/downloader.ts
@@ -1,10 +1,6 @@
 import { BaseConfiguration, ExtraConfiguration, LifeCycle, SuccessParam } from 'miniprogram-network-life-cycle';
 import { ParamsType } from 'miniprogram-network-utils';
-import { WxQueue } from 'miniprogram-queue';
 import { transfomDownloadSendDefault } from './transform';
-
-// tslint:disable-next-line: no-use-before-declare
-const downloadQueue = /*#__PURE__*/ new WxQueue<wx.DownloadFileOption, wx.DownloadTask>(wx.downloadFile);
 
 /**
  * 默认配置信息
@@ -94,7 +90,8 @@ export class Downloader
         listeners?: Downloader<T>['Listeners']
     ) {
         super(
-            downloader || downloadQueue.push.bind(downloadQueue),
+            // tslint:disable-next-line: no-use-before-declare
+            downloader || wx.downloadFile,
             // tslint:disable-next-line: no-object-literal-type-assertion
             config || { transformSend: transfomDownloadSendDefault } as DownloadInit<T>,
             listeners
@@ -183,12 +180,7 @@ export declare namespace wx {
          * 最低基础库： `1.4.0`
          */
         abort(): void;
-        // offHeadersReceived(
-        //   callback: DownloadTaskOffHeadersReceivedCallback,
-        // ): void;
-        // offProgressUpdate(
-        //   callback: DownloadTaskOffProgressUpdateCallback,
-        // ): void;
+
         onHeadersReceived(
             /** HTTP Response Header 事件的回调函数 */
             callback: DownloadTaskOnHeadersReceivedCallback

--- a/downloader/src/index.ts
+++ b/downloader/src/index.ts
@@ -3,7 +3,7 @@ export { Downloader, DownloadInit, DownloadOption } from './downloader';
 export {
     DownloadParams,
     transfomDownloadSendDefault,
-    transformDownloadResponseOkData 
+    transformDownloadResponseOkData
 } from './transform';
 
 import { Downloader } from './downloader';

--- a/life-cycle/src/configuration.ts
+++ b/life-cycle/src/configuration.ts
@@ -98,8 +98,9 @@ export interface BaseConfiguration<
 
     /**
      * 是否记录时间戳
+     * 如果传入为object 则记录时间戳于此object中
      */
-    timestamp?: boolean;
+    timestamp?: boolean | { send?: number; response?: number };
 
     /**
      * 请求参数预处理

--- a/life-cycle/src/configuration.ts
+++ b/life-cycle/src/configuration.ts
@@ -136,11 +136,6 @@ export interface ExtraConfiguration {
     cancelToken?: CancelToken;
 
     /**
-     * 是否插队
-     */
-    jump?: boolean;
-
-    /**
      * 自定义超时时间,单位`ms`
      * 取值`>0` 时有有效
      */

--- a/life-cycle/src/listeners.ts
+++ b/life-cycle/src/listeners.ts
@@ -57,7 +57,7 @@ type OnAbortListener<TFullOptions> = (reason: Readonly<any>, options: Readonly<T
 
 interface CommonCompleteResult extends GeneralCallbackResult {
     /**
-     * 时间戳记录, 通过miniprogram-queue发送并且timestamp设置为true
+     * 时间戳记录, 通过发送并且timestamp设置为true
      */
     time?: {
         /**

--- a/network-utils/src/index.ts
+++ b/network-utils/src/index.ts
@@ -54,7 +54,7 @@ export function getCommonOptions<T extends { [key: string]: any }>(
     options: { [key: string]: any },
     extendKeys: (keyof T)[]
 ): T {
-    (['jump', 'timestamp', 'timeout', 'expire', ...extendKeys] as string[]).forEach((v) => {
+    (['expire', ...extendKeys] as string[]).forEach((v) => {
         if (options[v] !== undefined) {
             data[v] = options[v];
         }

--- a/network/README.md
+++ b/network/README.md
@@ -48,7 +48,6 @@ post('xxx',data).then(console.log)
 
 ### 不同网络请求单独配置项
 
-* [x] `jump` 是否插队
 * [x] `timeout` 请求超时时间
 * [x] `cancelToken` 取消请求的Token
 * [x] `onHeadersReceived` header 接受回调

--- a/network/README.md
+++ b/network/README.md
@@ -17,10 +17,10 @@
 
 * [x] Promise<T>泛型Promise
 * [x] CancelToken 可取消操作
-* [x] Queue 队列支持(可插队)
 * [x] Retry 网络错误自动重试
 * [x] Cache 底层缓存支持(包括并发请求合并)
 * [x] Timeout 自定义超时时间
+* [x] timestamp 记录请求时间戳
 * [x] 每个请求的原生回调接口支持(`onHeadersReceived`事件)和(`onProgressUpdate`事件)
 * [x] Interceptors 拦截器 transform send data / transform response data
 * [x] Listeners 全局事件监听`onSend`,`onResponse`,`onRejected`,`onAbort`,`onComplete`

--- a/network/test/methods.ts
+++ b/network/test/methods.ts
@@ -11,8 +11,7 @@ upload('ss', 'testname');
 download('ss');
 download({
     url: 'sss',
-    jump: true,
     onHeadersReceived: function (res) {
         console.log(res.header)
     }
-} as Network.DownloadOption).then(res=>res.statusCode);
+} as Network.DownloadOption).then(res => res.statusCode);

--- a/request/README.md
+++ b/request/README.md
@@ -25,7 +25,6 @@
 * [x] `data` 数据 (_只能请求时设置for single request_) 
 * [x] `cancelToken` 取消 (_只能请求时设置for single request_) 
 * [x] `onHeadersReceived` 接收头响应 (_只能请求时设置for single request_) 
-* [x] `jump` 是否插队 (_只能请求时设置for single request_)
 * [x] `timeout` 自定义超时时间ms (_只能请求时设置for single request_)
 * [x] `responseType` 返回数据类型
 * [x] `headers` 请求头
@@ -173,11 +172,6 @@ REQUEST.Defaults.retry = 2;//设置网络错误时重试次数
      * 接收到响应头回调
      */
     onHeadersReceived?: TwxTask['onHeadersReceived'];
-
-    /**
-     * 是否插队
-     */
-    jump?: boolean;
 
     /**
     * 请求的根目录

--- a/request/package.json
+++ b/request/package.json
@@ -38,7 +38,6 @@
     },
     "dependencies": {
         "miniprogram-network-life-cycle": "^4.5.3",
-        "miniprogram-network-utils": "^4.5.2",
-        "miniprogram-queue": "^4.5.1"
+        "miniprogram-network-utils": "^4.5.2"
     }
 }

--- a/request/src/http.ts
+++ b/request/src/http.ts
@@ -1,13 +1,6 @@
 import { BaseConfiguration, ExtraConfiguration, LifeCycle, SuccessParam } from 'miniprogram-network-life-cycle';
 import { ParamsType } from 'miniprogram-network-utils';
-import { WxQueue } from 'miniprogram-queue';
 import { transformRequestSendDefault } from './transform';
-
-/**
- * 请求队列
- */
-// tslint:disable-next-line: no-use-before-declare
-const requestQueue = /*#__PURE__*/ new WxQueue<wx.RequestOption, wx.RequestTask>(wx.request);
 
 /**
  * 小程序HTTP 请求生命周期封装
@@ -36,7 +29,8 @@ export class Http<
         listeners?: Http<TExt>['Listeners']
     ) {
         super(
-            request || requestQueue.push.bind(requestQueue),
+            // tslint:disable-next-line: no-use-before-declare
+            request || wx.request,
             // tslint:disable-next-line: no-object-literal-type-assertion
             config || { transformSend: transformRequestSendDefault } as RequestInit<TExt>,
             listeners
@@ -387,16 +381,7 @@ export declare namespace wx {
          * 最低基础库： `1.4.0`
          */
         abort(): void;
-        /** [RequestTask.offHeadersReceived(function callback)](RequestTask.offHeadersReceived.md)
-         *
-         * 取消监听HTTP Response Header 事件，会比请求完成事件更早
-         *
-         * 最低基础库： `2.1.0`
-         */
-        // offHeadersReceived(
-        //   /** HTTP Response Header 事件的回调函数 */
-        //   callback: RequestTaskOffHeadersReceivedCallback,
-        // ): void;
+
         /** [RequestTask.onHeadersReceived(function callback)](RequestTask.onHeadersReceived.md)
          *
          * 监听HTTP Response Header 事件，会比请求完成事件更早

--- a/uploader/README.md
+++ b/uploader/README.md
@@ -21,7 +21,6 @@
 * [x] `cancelToken` 取消 (_只能请求时设置for single request_) 
 * [x] `onProgressUpdate` 下载进度响应 (_只能请求时设置for single request_) 
 * [x] `onHeadersReceived` 接收头响应 (_只能请求时设置for single request_) 
-* [x] `jump` 是否插队 (_只能请求时设置for single request_)
 * [x] `timeout` 自定义超时时间ms (_只能请求时设置for single request_)
 * [x] `url` 上传地址
 * [x] `headers` 请求头

--- a/uploader/package.json
+++ b/uploader/package.json
@@ -38,7 +38,6 @@
     },
     "dependencies": {
         "miniprogram-network-life-cycle": "^4.5.3",
-        "miniprogram-network-utils": "^4.5.2",
-        "miniprogram-queue": "^4.5.1"
+        "miniprogram-network-utils": "^4.5.2"
     }
 }

--- a/uploader/src/uploader.ts
+++ b/uploader/src/uploader.ts
@@ -1,11 +1,8 @@
 
 import { BaseConfiguration, ExtraConfiguration, LifeCycle, SuccessParam } from 'miniprogram-network-life-cycle';
 import { ParamsType } from 'miniprogram-network-utils';
-import { WxQueue } from 'miniprogram-queue';
 import { transformUploadSendDefault } from './transform';
 
-// tslint:disable-next-line: no-use-before-declare
-const uploadQueue = /*#__PURE__*/ new WxQueue<wx.UploadFileOption, wx.UploadTask>(wx.uploadFile);
 /**
  * 默认配置信息
  */
@@ -120,7 +117,8 @@ export class Uploader extends LifeCycle<
         listeners?: Uploader['Listeners']
     ) {
         super(
-            uploader || uploadQueue.push.bind(uploadQueue),
+            // tslint:disable-next-line: no-use-before-declare
+            uploader || wx.uploadFile,
             config || { transformSend: transformUploadSendDefault },
             listeners
         );


### PR DESCRIPTION
* [x] move timeout into lifecycle
* [x] move timestamp into lifecycle
* [x] move onProgressUpdate into lifecycle
* [x] move onHeadersReceived into lifecycle
* [x] remove miniprogram-queue dependency
* [x] remove `jump` from configuration

resolve #15 