### PR TITLE
feat(ensure-online)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # [miniprogram-network](https://github.com/NewFuture/miniprogram-network)
 
-> 小程序网络库,提供完整`代码自动完成` 和 `类型检查`,支持`Promise`、自动`重试`、`缓存`、`取消`、`自定义超时`、全局`拦截`、和`事件监听`等……
+> 小程序网络库,提供完整`代码自动完成` 和 `类型检查`,支持`Promise`、自动`重试`、`缓存`、`取消`、`自定义超时`、`自动暂停恢复`、全局`拦截`、和`事件监听`等……
 >
-> Redefine the network API of Wechat MiniProgram, including full `IntelliSense` and `Type Checking`, with `Promise`,`retry`,`Cache`,`CancelToken`,`timeout`, global `interceptors`, `event listeners` and more.
+> Redefine the network API of Wechat MiniProgram, including full `IntelliSense` and `Type Checking`, with `Promise`,`retry`,`Cache`,`CancelToken`,`timeout`,`ensureOnline`, global `interceptors`, `event listeners` and more.
 
 ## Features 主要功能
 
@@ -11,6 +11,7 @@
 * [x] Cache 底层缓存支持(包括并发请求合并)
 * [x] CancelToken 可取消操作
 * [x] Timeout 自定义超时时间
+* [x] 确保网络可用时发送请求,离线和切换到后台时暂停发送请求
 * [x] timestamp 记录耗时统计(需开启配置)
 * [x] 每个请求的原生回调接口支持(`onHeadersReceived`事件)和(`onProgressUpdate`事件)
 * [x] Interceptors 拦截器 `transformSend`/ `transformRresponse`自定义数据拦截

--- a/cache/src/cache-operator.ts
+++ b/cache/src/cache-operator.ts
@@ -165,7 +165,7 @@ export class CacheOperator<
                 success: options.success ? [options.success] : [],
                 fail: options.fail ? [options.fail] : [],
                 complete: options.complete ? [options.complete] : [],
-                task: {} as WxTask,
+                task: {} as WxTask
             };
             // 微信task同步创建异步调用
             // 防止同步执行fail时 this.callbackListMap[key] 还未赋值

--- a/life-cycle/src/configuration.ts
+++ b/life-cycle/src/configuration.ts
@@ -83,6 +83,12 @@ export interface BaseConfiguration<
     timestamp?: boolean | { send?: number; response?: number };
 
     /**
+     * 禁用在线检查功能，离线状态也强制发送请求
+     * 默认，会检查在线状态，离线或者后台时暂停发送
+     */
+    disableOnline?: boolean;
+
+    /**
      * 请求参数预处理
      * 修改数据或者头;返回 wx.request, wx.downloadFile,wx.uploadFile参数 (不包括回调函数)
      * 支持异步返回promise

--- a/life-cycle/src/ensure-online.ts
+++ b/life-cycle/src/ensure-online.ts
@@ -1,0 +1,85 @@
+import { CancelToken } from 'miniprogram-cancel-token';
+// tslint:disable: no-use-before-declare
+
+/**
+ * 网络是否联接
+ */
+let isConnected: boolean = false;
+/**
+ * 是否隐藏在后台
+ */
+let isHidden: boolean = false;
+
+const callbackPools: (() => void)[] = [];
+
+function checkCallbacks() {
+    if (isConnected && !isHidden) {
+        while (callbackPools.length > 0) {
+            callbackPools.shift()!();
+        }
+    }
+}
+wx.onAppHide(() => { isHidden = true; });
+wx.onAppShow(() => {
+    isHidden = false;
+    checkCallbacks();
+});
+wx.onNetworkStatusChange((res) => {
+    isConnected = res.isConnected;
+    checkCallbacks();
+});
+wx.getNetworkType({
+    success(res) {
+        isConnected = res.networkType !== 'none';
+        checkCallbacks();
+    }
+});
+
+/**
+ * 确保在线时执行
+ * 网络掉线或者切换到后台的情况暂停发送
+ * @param callback 回调
+ * @param cancelToken 取消操作
+ */
+export function ensureOnline(callback: () => void, cancelToken?: CancelToken): void {
+    if (isConnected && !isHidden) {
+        callback();
+    } else {
+        callbackPools.push(callback);
+        if (cancelToken) {
+            // tslint:disable-next-line: no-floating-promises
+            cancelToken.promise.then(() => {
+                const index = callbackPools.indexOf(callback);
+                if (index !== -1) {
+                    callbackPools.splice(index, 1);
+                }
+            });
+        }
+    }
+}
+
+declare namespace wx {
+    interface OnNetworkStatusChangeCallbackResult {
+        /** 当前是否有网络连接 */
+        isConnected: boolean;
+        /** 网络类型
+         *
+         * 可选值：
+         * - 'wifi': wifi 网络;
+         * - '2g': 2g 网络;
+         * - '3g': 3g 网络;
+         * - '4g': 4g 网络;
+         * - 'unknown': Android 下不常见的网络类型;
+         * - 'none': 无网络;
+         */
+        networkType: 'wifi' | '2g' | '3g' | '4g' | 'unknown' | 'none';
+    }
+
+    function getNetworkType(option?: { success?(result: OnNetworkStatusChangeCallbackResult): void }): void;
+    /** 网络状态变化事件的回调函数 */
+    function onNetworkStatusChange(callback: (result: OnNetworkStatusChangeCallbackResult) => void): void;
+    /** 小程序切后台事件的回调函数 */
+    function onAppHide(callback: () => void): void;
+    /** 小程序切前台事件的回调函数 */
+    function onAppShow(callback: () => void): void;
+}


### PR DESCRIPTION
离线或切换后台时，自动暂停，恢复后自动发送请求 #5 

 - miniprogram-network-cache@5.1.11-alpha.0+f0c8d23
 - miniprogram-downloader@5.1.11-alpha.0+f0c8d23
 - miniprogram-network-life-cycle@5.1.11-alpha.0+f0c8d23
 - miniprogram-network@5.1.11-alpha.0+f0c8d23
 - miniprogram-request@5.1.11-alpha.0+f0c8d23
 - miniprogram-uploader@5.1.11-alpha.0+f0c8d23